### PR TITLE
Add Command Line Options and Mouse Click Support

### DIFF
--- a/Biped.sln
+++ b/Biped.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27428.2011
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30804.86
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "biped", "biped\biped.csproj", "{9F9F12F0-FBEE-4E42-94AE-364D363A67CA}"
 EndProject

--- a/Biped/App.xaml
+++ b/Biped/App.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:biped"
-             StartupUri="MainWindow.xaml">
+             Startup="Application_Startup">
     <Application.Resources>
          
     </Application.Resources>

--- a/Biped/App.xaml.cs
+++ b/Biped/App.xaml.cs
@@ -13,5 +13,70 @@ namespace biped
     /// </summary>
     public partial class App : Application
     {
+        private void Application_Startup(object sender, StartupEventArgs e)
+        {
+            MainWindow wnd = new MainWindow();
+
+            if (e.Args.Length > 0)
+            {
+                var cliBindings = ProcessCommandLineArguments(e.Args);
+                if (cliBindings.Length == 3)
+                {
+                    wnd.ApplyCommandLineBindings(cliBindings[0], cliBindings[1], cliBindings[2]);
+                }
+            }
+            wnd.Show();
+        }
+
+        private uint[] ProcessCommandLineArguments(string[] args)
+        {
+
+            uint leftBinding = uint.MaxValue;
+            uint middleBinding = uint.MaxValue;
+            uint rightBinding = uint.MaxValue;
+            int argIndex = 0;
+            
+            try
+            {
+                while (argIndex < args.Length)
+                {
+                    switch (args[argIndex])
+                    {
+                        case "-left":
+                            argIndex++;
+                            leftBinding = uint.Parse(args[argIndex]);
+                            break;
+                        case "-middle":
+                            argIndex++;
+                            middleBinding = uint.Parse(args[argIndex]);
+                            break;
+                        case "-right":
+                            argIndex++;
+                            rightBinding = uint.Parse(args[argIndex]);
+                            break;
+                        default:
+                            throw new Exception();
+                    }
+                    argIndex++;
+                }
+
+                if (leftBinding == uint.MaxValue || middleBinding == uint.MaxValue || rightBinding == uint.MaxValue ) {
+                    MessageBox.Show("Must provide bindings for all three pedals!");
+                    return new uint[0];
+                }
+            }
+            catch (FormatException f)
+            {
+                MessageBox.Show("Binding values must be the integer key system code.");
+                return new uint[0];
+            }
+            catch (Exception e)
+            {
+                MessageBox.Show("Invalid Command Line Parameters!");
+                return new uint[0];
+            }
+
+            return new uint[]{ leftBinding, middleBinding, rightBinding };
+        }
     }
 }

--- a/Biped/App.xaml.cs
+++ b/Biped/App.xaml.cs
@@ -13,5 +13,70 @@ namespace biped
     /// </summary>
     public partial class App : Application
     {
+        private void Application_Startup(object sender, StartupEventArgs e)
+        {
+            MainWindow wnd = new MainWindow();
+
+            if (e.Args.Length > 0)
+            {
+                var cliBindings = ProcessCommandLineArguments(e.Args);
+                if (cliBindings.Length == 3)
+                {
+                    wnd.ApplyCommandLineBindings(cliBindings[0], cliBindings[1], cliBindings[2]);
+                }
+            }
+            wnd.Show();
+        }
+
+        private uint[] ProcessCommandLineArguments(string[] args)
+        {
+
+            uint leftBinding = uint.MaxValue;
+            uint middleBinding = uint.MaxValue;
+            uint rightBinding = uint.MaxValue;
+            int argIndex = 0;
+            
+            try
+            {
+                while (argIndex < args.Length)
+                {
+                    switch (args[argIndex])
+                    {
+                        case "-left":
+                            argIndex++;
+                            leftBinding = uint.Parse(args[argIndex]);
+                            break;
+                        case "-middle":
+                            argIndex++;
+                            middleBinding = uint.Parse(args[argIndex]);
+                            break;
+                        case "-right":
+                            argIndex++;
+                            rightBinding = uint.Parse(args[argIndex]);
+                            break;
+                        default:
+                            throw new Exception();
+                    }
+                    argIndex++;
+                }
+
+                if (leftBinding == uint.MaxValue || middleBinding == uint.MaxValue || rightBinding == uint.MaxValue ) {
+                    MessageBox.Show("Must provide bindings for all three pedals!");
+                    return new uint[0];
+                }
+            }
+            catch (FormatException)
+            {
+                MessageBox.Show("Binding values must be the integer key code!");
+                return new uint[0];
+            }
+            catch (Exception)
+            {
+                MessageBox.Show("Invalid Command Line Parameters!");
+                return new uint[0];
+            }
+
+            return new uint[]{ leftBinding, middleBinding, rightBinding };
+        }
     }
 }

--- a/Biped/App.xaml.cs
+++ b/Biped/App.xaml.cs
@@ -65,12 +65,12 @@ namespace biped
                     return new uint[0];
                 }
             }
-            catch (FormatException f)
+            catch (FormatException)
             {
-                MessageBox.Show("Binding values must be the integer key system code.");
+                MessageBox.Show("Binding values must be the integer key code!");
                 return new uint[0];
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 MessageBox.Show("Invalid Command Line Parameters!");
                 return new uint[0];

--- a/Biped/Biped.cs
+++ b/Biped/Biped.cs
@@ -34,7 +34,7 @@ namespace biped
         private PedalState RightState = PedalState.UP;
 
         private readonly Input input = new Input();
-        private readonly Config config;
+        private Config config { get; set; }
         public bool DeviceConnected { get; set; }
 
         public Biped(Config config)
@@ -54,6 +54,11 @@ namespace biped
 
                 device.ReadReport(OnReport);
             }
+        }
+
+        public void UpdateConfig(Config config)
+        {
+            this.config = config;
         }
 
         private void OnReport(HidReport report)

--- a/Biped/Config.cs
+++ b/Biped/Config.cs
@@ -7,6 +7,8 @@ namespace biped
         public uint Middle { get; set; }
         public uint Right { get; set; }
 
+        public enum MOUSE_BUTTON_CODES { Left = 1000, Middle = 2000, Right = 3000 };
+
         public Config(uint left, uint middle, uint right)
         {
             Left = left;

--- a/Biped/Config.cs
+++ b/Biped/Config.cs
@@ -7,8 +7,6 @@ namespace biped
         public uint Middle { get; set; }
         public uint Right { get; set; }
 
-        public enum MOUSE_BUTTON_CODES { Left = 1000, Middle = 2000, Right = 3000 };
-
         public Config(uint left, uint middle, uint right)
         {
             Left = left;

--- a/Biped/CustomButtonCodes.cs
+++ b/Biped/CustomButtonCodes.cs
@@ -1,0 +1,12 @@
+﻿namespace biped
+{
+    public class CustomButtons
+    {
+        public enum MOUSE_BUTTON_CODES { 
+            MouseLeft = 1000, 
+            MouseMiddle = 2000, 
+            MouseRight = 3000 
+        };
+
+    }
+}

--- a/Biped/Input.cs
+++ b/Biped/Input.cs
@@ -29,20 +29,24 @@ namespace biped
             }
 
             INPUT input;
-            if (keyCode == 1000 || keyCode == 2000 || keyCode == 3000)
+
+            //if (keyCode == 1000 || keyCode == 2000 || keyCode == 3000)
+            if (Enum.IsDefined(typeof(CustomButtons.MOUSE_BUTTON_CODES), keyCode))
             {
                 uint mFlags = 0;
                 switch (keyCode)
                 {
-                    case 1000:
+                    case (uint)CustomButtons.MOUSE_BUTTON_CODES.MouseLeft:
                         mFlags = state == PedalState.UP ? MOUSEEVENTF_LEFTUP : MOUSEEVENTF_LEFTDOWN;
                         break;
-                    case 2000:
+                    case (uint)CustomButtons.MOUSE_BUTTON_CODES.MouseMiddle:
                         mFlags = state == PedalState.UP ? MOUSEEVENTF_MIDDLEUP : MOUSEEVENTF_MIDDLEDOWN;
                         break;
-                    case 3000:
+                    case (uint)CustomButtons.MOUSE_BUTTON_CODES.MouseRight:
                         mFlags = state == PedalState.UP ? MOUSEEVENTF_RIGHTUP : MOUSEEVENTF_RIGHTDOWN;
                         break;
+                    default:
+                        return;
                 }
 
                 input = new INPUT

--- a/Biped/Input.cs
+++ b/Biped/Input.cs
@@ -1,11 +1,19 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-
 namespace biped
 {
     class Input
     {
+        private const uint MOUSEEVENTF_MOVE = 0x0001;
+        private const uint MOUSEEVENTF_LEFTDOWN = 0x0002;
+        private const uint MOUSEEVENTF_LEFTUP = 0x0004;
+        private const uint MOUSEEVENTF_RIGHTDOWN = 0x0008;
+        private const uint MOUSEEVENTF_RIGHTUP = 0x0010;
+        private const uint MOUSEEVENTF_MIDDLEDOWN = 0x0020;
+        private const uint MOUSEEVENTF_MIDDLEUP = 0x0040;
+        private const uint MOUSEEVENTF_ABSOLUTE = 0x8000;
+
         private static readonly uint KEYEVENTF_SCANCODE = 0x08;
         private static readonly uint KEYEVENTF_KEYUP = 0x02;
         [DllImport("user32.dll")]
@@ -19,23 +27,59 @@ namespace biped
                 flags |= KEYEVENTF_KEYUP;
             }
 
-            INPUT input = new INPUT
+            INPUT input;
+
+            switch (keyCode)
             {
-                Type = 1
-            };
-            input.Data.Keyboard = new KEYBDINPUT
-            {
-                Vk = 0,
-                Scan = (ushort)keyCode,
-                Flags = flags,
-                Time = 0,
-                ExtraInfo = IntPtr.Zero
-            };
+                case (uint)CustomButtons.MOUSE_BUTTON_CODES.MouseLeft:
+                    input = NewMouseClickInput(state == PedalState.UP ? MOUSEEVENTF_LEFTUP : MOUSEEVENTF_LEFTDOWN);
+                    break;
+                case (uint)CustomButtons.MOUSE_BUTTON_CODES.MouseMiddle:
+                    input = NewMouseClickInput(state == PedalState.UP ? MOUSEEVENTF_MIDDLEUP : MOUSEEVENTF_MIDDLEDOWN);
+                    break;
+                case (uint)CustomButtons.MOUSE_BUTTON_CODES.MouseRight:
+                    input = NewMouseClickInput(state == PedalState.UP ? MOUSEEVENTF_RIGHTUP : MOUSEEVENTF_RIGHTDOWN);
+                    break;
+                default:
+                    input = new INPUT
+                    {
+                        Type = 1
+                    };
+                    input.Data.Keyboard = new KEYBDINPUT
+                    {
+                        Vk = 0,
+                        Scan = (ushort)keyCode,
+                        Flags = flags,
+                        Time = 0,
+                        ExtraInfo = IntPtr.Zero
+                    };
+                    
+                    break;
+            }
+
             INPUT[] inputs = new INPUT[] { input };
             if (SendInput(1, inputs, Marshal.SizeOf(typeof(INPUT))) == 0)
             {
                 Console.WriteLine("Error in sendKey");
             }
+        }
+
+        private INPUT NewMouseClickInput(uint flags)
+        {
+            var i = new INPUT
+            {
+                Type = 0
+            };
+            i.Data.Mouse = new MOUSEINPUT
+            {
+                X = 0,
+                Y = 0,
+                MouseData = 0,
+                Flags = flags,
+                Time = 0,
+                ExtraInfo = IntPtr.Zero
+            };
+            return i;
         }
 
         /// <summary>

--- a/Biped/Input.cs
+++ b/Biped/Input.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Runtime.InteropServices;
-using System.Windows.Controls;
 
 namespace biped
 {

--- a/Biped/Input.cs
+++ b/Biped/Input.cs
@@ -30,59 +30,57 @@ namespace biped
 
             INPUT input;
 
-            //if (keyCode == 1000 || keyCode == 2000 || keyCode == 3000)
-            if (Enum.IsDefined(typeof(CustomButtons.MOUSE_BUTTON_CODES), keyCode))
+            switch (keyCode)
             {
-                uint mFlags = 0;
-                switch (keyCode)
-                {
-                    case (uint)CustomButtons.MOUSE_BUTTON_CODES.MouseLeft:
-                        mFlags = state == PedalState.UP ? MOUSEEVENTF_LEFTUP : MOUSEEVENTF_LEFTDOWN;
-                        break;
-                    case (uint)CustomButtons.MOUSE_BUTTON_CODES.MouseMiddle:
-                        mFlags = state == PedalState.UP ? MOUSEEVENTF_MIDDLEUP : MOUSEEVENTF_MIDDLEDOWN;
-                        break;
-                    case (uint)CustomButtons.MOUSE_BUTTON_CODES.MouseRight:
-                        mFlags = state == PedalState.UP ? MOUSEEVENTF_RIGHTUP : MOUSEEVENTF_RIGHTDOWN;
-                        break;
-                    default:
-                        return;
-                }
+                case (uint)CustomButtons.MOUSE_BUTTON_CODES.MouseLeft:
+                    input = NewMouseClickInput(state == PedalState.UP ? MOUSEEVENTF_LEFTUP : MOUSEEVENTF_LEFTDOWN);
+                    break;
+                case (uint)CustomButtons.MOUSE_BUTTON_CODES.MouseMiddle:
+                    input = NewMouseClickInput(state == PedalState.UP ? MOUSEEVENTF_MIDDLEUP : MOUSEEVENTF_MIDDLEDOWN);
+                    break;
+                case (uint)CustomButtons.MOUSE_BUTTON_CODES.MouseRight:
+                    input = NewMouseClickInput(state == PedalState.UP ? MOUSEEVENTF_RIGHTUP : MOUSEEVENTF_RIGHTDOWN);
+                    break;
+                default:
+                    input = new INPUT
+                    {
+                        Type = 1
+                    };
+                    input.Data.Keyboard = new KEYBDINPUT
+                    {
+                        Vk = 0,
+                        Scan = (ushort)keyCode,
+                        Flags = flags,
+                        Time = 0,
+                        ExtraInfo = IntPtr.Zero
+                    };
+                    
+                    break;
+            }
 
-                input = new INPUT
-                {
-                    Type = 0
-                };
-                input.Data.Mouse = new MOUSEINPUT
-                {
-                    X = 0,
-                    Y = 0,
-                    MouseData = 0,
-                    Flags = mFlags,
-                    Time = 0,
-                    ExtraInfo = IntPtr.Zero
-                };
-            }
-            else
-            {
-                input = new INPUT
-                {
-                    Type = 1
-                };
-                input.Data.Keyboard = new KEYBDINPUT
-                {
-                    Vk = 0,
-                    Scan = (ushort)keyCode,
-                    Flags = flags,
-                    Time = 0,
-                    ExtraInfo = IntPtr.Zero
-                };
-            }
             INPUT[] inputs = new INPUT[] { input };
             if (SendInput(1, inputs, Marshal.SizeOf(typeof(INPUT))) == 0)
             {
                 Console.WriteLine("Error in sendKey");
             }
+        }
+
+        private INPUT NewMouseClickInput(uint flags)
+        {
+            var i = new INPUT
+            {
+                Type = 0
+            };
+            i.Data.Mouse = new MOUSEINPUT
+            {
+                X = 0,
+                Y = 0,
+                MouseData = 0,
+                Flags = flags,
+                Time = 0,
+                ExtraInfo = IntPtr.Zero
+            };
+            return i;
         }
 
         /// <summary>

--- a/Biped/Input.cs
+++ b/Biped/Input.cs
@@ -1,11 +1,20 @@
 ﻿using System;
 using System.Runtime.InteropServices;
-
+using System.Windows.Controls;
 
 namespace biped
 {
     class Input
     {
+        private const uint MOUSEEVENTF_MOVE = 0x0001;
+        private const uint MOUSEEVENTF_LEFTDOWN = 0x0002;
+        private const uint MOUSEEVENTF_LEFTUP = 0x0004;
+        private const uint MOUSEEVENTF_RIGHTDOWN = 0x0008;
+        private const uint MOUSEEVENTF_RIGHTUP = 0x0010;
+        private const uint MOUSEEVENTF_MIDDLEDOWN = 0x0020;
+        private const uint MOUSEEVENTF_MIDDLEUP = 0x0040;
+        private const uint MOUSEEVENTF_ABSOLUTE = 0x8000;
+
         private static readonly uint KEYEVENTF_SCANCODE = 0x08;
         private static readonly uint KEYEVENTF_KEYUP = 0x02;
         [DllImport("user32.dll")]
@@ -19,18 +28,52 @@ namespace biped
                 flags |= KEYEVENTF_KEYUP;
             }
 
-            INPUT input = new INPUT
+            INPUT input;
+            if (keyCode == 1000 || keyCode == 2000 || keyCode == 3000)
             {
-                Type = 1
-            };
-            input.Data.Keyboard = new KEYBDINPUT
+                uint mFlags = 0;
+                switch (keyCode)
+                {
+                    case 1000:
+                        mFlags = state == PedalState.UP ? MOUSEEVENTF_LEFTUP : MOUSEEVENTF_LEFTDOWN;
+                        break;
+                    case 2000:
+                        mFlags = state == PedalState.UP ? MOUSEEVENTF_MIDDLEUP : MOUSEEVENTF_MIDDLEDOWN;
+                        break;
+                    case 3000:
+                        mFlags = state == PedalState.UP ? MOUSEEVENTF_RIGHTUP : MOUSEEVENTF_RIGHTDOWN;
+                        break;
+                }
+
+                input = new INPUT
+                {
+                    Type = 0
+                };
+                input.Data.Mouse = new MOUSEINPUT
+                {
+                    X = 0,
+                    Y = 0,
+                    MouseData = 0,
+                    Flags = mFlags,
+                    Time = 0,
+                    ExtraInfo = IntPtr.Zero
+                };
+            }
+            else
             {
-                Vk = 0,
-                Scan = (ushort)keyCode,
-                Flags = flags,
-                Time = 0,
-                ExtraInfo = IntPtr.Zero
-            };
+                input = new INPUT
+                {
+                    Type = 1
+                };
+                input.Data.Keyboard = new KEYBDINPUT
+                {
+                    Vk = 0,
+                    Scan = (ushort)keyCode,
+                    Flags = flags,
+                    Time = 0,
+                    ExtraInfo = IntPtr.Zero
+                };
+            }
             INPUT[] inputs = new INPUT[] { input };
             if (SendInput(1, inputs, Marshal.SizeOf(typeof(INPUT))) == 0)
             {

--- a/Biped/MainWindow.xaml
+++ b/Biped/MainWindow.xaml
@@ -7,7 +7,7 @@
         xmlns:tb="http://www.hardcodet.net/taskbar"
         mc:Ignorable="d"
         Title="Biped" Height="190" Width="260"
-        KeyUp="OnKeyUp" Closing="Window_Closing" >
+        KeyUp="OnKeyUp" Closing="Window_Closing" MouseDown="OnMouseDown">
 
 
     <Window.Resources>

--- a/Biped/MainWindow.xaml.cs
+++ b/Biped/MainWindow.xaml.cs
@@ -115,19 +115,6 @@ namespace biped
             LoadPedalBinds();
         }
 
-        public void ApplyCommandLineBindings(uint left, uint middle, uint right)
-        {
-            System.Diagnostics.Debug.WriteLine($"Applying Keybind Left: {VKeyToKey(VKeyFromScanCode(left)).ToString()} ({left}), " +
-                            $"Middle: {VKeyToKey(VKeyFromScanCode(middle)).ToString()} ({middle}), " +
-                            $"Right: {VKeyToKey(VKeyFromScanCode(right)).ToString()} ({right})");
-
-            SavePedalBind(Pedal.LEFT, left);
-            SavePedalBind(Pedal.MIDDLE, middle);
-            SavePedalBind(Pedal.RIGHT, right);
-
-            LoadPedalBinds();
-        }
-
         private void RecordPedalBind(Pedal pedal)
         {
             if (biped.DeviceConnected)

--- a/Biped/MainWindow.xaml.cs
+++ b/Biped/MainWindow.xaml.cs
@@ -59,31 +59,32 @@ namespace biped
             }
         }
 
+        public void ApplyCommandLineBindings(uint left, uint middle, uint right)
+        {
+            MessageBox.Show($"Applying Keybind Left: {VKeyToKey(VKeyFromScanCode(left)).ToString()} ({left}), " +
+                            $"Middle: {VKeyToKey(VKeyFromScanCode(middle)).ToString()} ({middle}), " +
+                            $"Right: {VKeyToKey(VKeyFromScanCode(right)).ToString()} ({right})");
+
+            SavePedalBind(Pedal.LEFT, left);
+            SavePedalBind(Pedal.MIDDLE, middle);
+            SavePedalBind(Pedal.RIGHT, right);
+
+            LoadPedalBinds();
+        }
+
         private void RecordPedalBind(Pedal pedal)
         {
-            if (biped.DeviceConnected)
-            {
+            //if (biped.DeviceConnected)
+            //{
                 currentPedalToSet = pedal;
                 StatusText.Content = BIND_KEY_TEXT;
-            }
+            //}
         }
 
         private void OnKeyUp(object sender, KeyEventArgs args)
         {
-            switch (currentPedalToSet)
-            {
-                case Pedal.LEFT:
-                    LeftText.Content = args.Key;
-                    break;
-                case Pedal.MIDDLE:
-                    MiddleText.Content = args.Key;
-                    break;
-                case Pedal.RIGHT:
-                    RightText.Content = args.Key;
-                    break;
-                case Pedal.NONE:
-                    return;
-            }
+            if (currentPedalToSet == Pedal.NONE) 
+                return;
 
             int vKey = KeyInterop.VirtualKeyFromKey(args.Key);
             uint scanCode = ScanCodeFromVKey(vKey);
@@ -92,6 +93,7 @@ namespace biped
             StatusText.Content = BIND_BUTTON_TEXT;
             currentPedalToSet = Pedal.NONE;
 
+            LoadPedalBinds();
         }
 
         private void SavePedalBind(Pedal pedal, uint keyCode)
@@ -138,9 +140,9 @@ namespace biped
             uint right = settings.GetFromRegistry(Pedal.RIGHT.ToString("g"));
 
             config = new Config(left, middle, right);
-            LeftText.Content = VKeyToKey(VKeyFromScanCode(left)).ToString();
-            MiddleText.Content = VKeyToKey(VKeyFromScanCode(middle)).ToString();
-            RightText.Content = VKeyToKey(VKeyFromScanCode(right)).ToString();
+            LeftText.Content = $"{VKeyToKey(VKeyFromScanCode(left)).ToString()} ({left})";
+            MiddleText.Content = $"{VKeyToKey(VKeyFromScanCode(middle)).ToString()} ({middle})";
+            RightText.Content = $"{VKeyToKey(VKeyFromScanCode(right)).ToString()} ({right})";
         }
 
         private void LeftText_PreviewMouseUp(object sender, MouseButtonEventArgs e)

--- a/Biped/MainWindow.xaml.cs
+++ b/Biped/MainWindow.xaml.cs
@@ -47,6 +47,8 @@ namespace biped
         private readonly Biped biped;
         private Config config;
 
+        private DateTime lastBindTime;
+
         private Pedal currentPedalToSet = Pedal.NONE;
         public MainWindow()
         {
@@ -59,10 +61,26 @@ namespace biped
             }
         }
 
+        public void ApplyCommandLineBindings(uint left, uint middle, uint right)
+        {
+            System.Diagnostics.Debug.WriteLine($"Applying Keybind Left: {VKeyToKey(VKeyFromScanCode(left)).ToString()} ({left}), " +
+                            $"Middle: {VKeyToKey(VKeyFromScanCode(middle)).ToString()} ({middle}), " +
+                            $"Right: {VKeyToKey(VKeyFromScanCode(right)).ToString()} ({right})");
+
+            SavePedalBind(Pedal.LEFT, left);
+            SavePedalBind(Pedal.MIDDLE, middle);
+            SavePedalBind(Pedal.RIGHT, right);
+
+            LoadPedalBinds();
+        }
+
         private void RecordPedalBind(Pedal pedal)
         {
             if (biped.DeviceConnected)
             {
+                if (WasJustBound())
+                   return;
+
                 currentPedalToSet = pedal;
                 StatusText.Content = BIND_KEY_TEXT;
             }
@@ -70,20 +88,8 @@ namespace biped
 
         private void OnKeyUp(object sender, KeyEventArgs args)
         {
-            switch (currentPedalToSet)
-            {
-                case Pedal.LEFT:
-                    LeftText.Content = args.Key;
-                    break;
-                case Pedal.MIDDLE:
-                    MiddleText.Content = args.Key;
-                    break;
-                case Pedal.RIGHT:
-                    RightText.Content = args.Key;
-                    break;
-                case Pedal.NONE:
-                    return;
-            }
+            if (currentPedalToSet == Pedal.NONE) 
+                return;
 
             int vKey = KeyInterop.VirtualKeyFromKey(args.Key);
             uint scanCode = ScanCodeFromVKey(vKey);
@@ -92,6 +98,30 @@ namespace biped
             StatusText.Content = BIND_BUTTON_TEXT;
             currentPedalToSet = Pedal.NONE;
 
+            LoadPedalBinds(true);
+        }
+
+        private void OnMouseDown(object sender, MouseEventArgs args)
+        {
+            if (currentPedalToSet == Pedal.NONE)
+                return;
+
+            if (args.LeftButton == MouseButtonState.Pressed)
+            {
+                SavePedalBind(currentPedalToSet, (uint)CustomButtons.MOUSE_BUTTON_CODES.MouseLeft);
+            }
+            else if (args.MiddleButton == MouseButtonState.Pressed)
+            {
+                SavePedalBind(currentPedalToSet, (uint)CustomButtons.MOUSE_BUTTON_CODES.MouseMiddle);
+            }
+            else if (args.RightButton == MouseButtonState.Pressed)
+            {
+                SavePedalBind(currentPedalToSet, (uint)CustomButtons.MOUSE_BUTTON_CODES.MouseRight);
+            }
+
+            StatusText.Content = BIND_BUTTON_TEXT;
+            currentPedalToSet = Pedal.NONE;
+            LoadPedalBinds(true);
         }
 
         private void SavePedalBind(Pedal pedal, uint keyCode)
@@ -109,12 +139,12 @@ namespace biped
                     config.Right = keyCode;
                     break;
             }
+            lastBindTime = DateTime.Now;
         }
 
         private Key VKeyToKey(int vKey)
         {
             return KeyInterop.KeyFromVirtualKey(vKey);
-            
         }
 
         [DllImport("user32.dll")]
@@ -131,16 +161,40 @@ namespace biped
             return (int)MapVirtualKey(scanCode, MapType.MAPVK_VSC_TO_VK);
         }
 
-        private void LoadPedalBinds()
+        private string GetLabelContent(uint btnCode)
+        {
+            switch (btnCode)
+            {
+                case (uint)CustomButtons.MOUSE_BUTTON_CODES.MouseLeft:
+                    return $"Mouse Btn Left ({btnCode})";
+                case (uint)CustomButtons.MOUSE_BUTTON_CODES.MouseMiddle:
+                    return $"Mouse Btn Middle ({btnCode})";
+                case (uint)CustomButtons.MOUSE_BUTTON_CODES.MouseRight:
+                    return $"Mouse Btn Right ({btnCode})";
+                default:
+                    return $"{VKeyToKey(VKeyFromScanCode(btnCode)).ToString()} ({btnCode})";
+            }
+        }
+
+        private void LoadPedalBinds(bool update = false)
         {
             uint left = settings.GetFromRegistry(Pedal.LEFT.ToString("g"));
             uint middle = settings.GetFromRegistry(Pedal.MIDDLE.ToString("g"));
             uint right = settings.GetFromRegistry(Pedal.RIGHT.ToString("g"));
 
             config = new Config(left, middle, right);
-            LeftText.Content = VKeyToKey(VKeyFromScanCode(left)).ToString();
-            MiddleText.Content = VKeyToKey(VKeyFromScanCode(middle)).ToString();
-            RightText.Content = VKeyToKey(VKeyFromScanCode(right)).ToString();
+
+            LeftText.Content = GetLabelContent(left);
+            MiddleText.Content = GetLabelContent(middle);
+            RightText.Content = GetLabelContent(right);
+
+            if (update)
+                biped.UpdateConfig(config);
+        }
+
+        private bool WasJustBound()
+        {
+            return lastBindTime.AddSeconds(0.5) > DateTime.Now;
         }
 
         private void LeftText_PreviewMouseUp(object sender, MouseButtonEventArgs e)
@@ -151,13 +205,11 @@ namespace biped
         private void MiddleText_PreviewMouseUp(object sender, MouseButtonEventArgs e)
         {
             RecordPedalBind(Pedal.MIDDLE);
-
         }
 
         private void RightText_PreviewMouseUp(object sender, MouseButtonEventArgs e)
         {
             RecordPedalBind(Pedal.RIGHT);
-
         }
 
         private void MenuQuit_Click(object sender, RoutedEventArgs e)

--- a/Biped/MainWindow.xaml.cs
+++ b/Biped/MainWindow.xaml.cs
@@ -61,7 +61,7 @@ namespace biped
 
         public void ApplyCommandLineBindings(uint left, uint middle, uint right)
         {
-            MessageBox.Show($"Applying Keybind Left: {VKeyToKey(VKeyFromScanCode(left)).ToString()} ({left}), " +
+            System.Diagnostics.Debug.WriteLine($"Applying Keybind Left: {VKeyToKey(VKeyFromScanCode(left)).ToString()} ({left}), " +
                             $"Middle: {VKeyToKey(VKeyFromScanCode(middle)).ToString()} ({middle}), " +
                             $"Right: {VKeyToKey(VKeyFromScanCode(right)).ToString()} ({right})");
 

--- a/Biped/MainWindow.xaml.cs
+++ b/Biped/MainWindow.xaml.cs
@@ -47,6 +47,8 @@ namespace biped
         private readonly Biped biped;
         private Config config;
 
+        private DateTime lastBindTime;
+
         private Pedal currentPedalToSet = Pedal.NONE;
         public MainWindow()
         {
@@ -76,6 +78,9 @@ namespace biped
         {
             if (biped.DeviceConnected)
             {
+                if (WasJustBound())
+                   return;
+
                 currentPedalToSet = pedal;
                 StatusText.Content = BIND_KEY_TEXT;
             }
@@ -103,15 +108,15 @@ namespace biped
 
             if (args.LeftButton == MouseButtonState.Pressed)
             {
-                SavePedalBind(currentPedalToSet, (uint)Config.MOUSE_BUTTON_CODES.Left);
+                SavePedalBind(currentPedalToSet, (uint)CustomButtons.MOUSE_BUTTON_CODES.MouseLeft);
             }
             else if (args.MiddleButton == MouseButtonState.Pressed)
             {
-                SavePedalBind(currentPedalToSet, (uint)Config.MOUSE_BUTTON_CODES.Middle);
+                SavePedalBind(currentPedalToSet, (uint)CustomButtons.MOUSE_BUTTON_CODES.MouseMiddle);
             }
             else if (args.RightButton == MouseButtonState.Pressed)
             {
-                SavePedalBind(currentPedalToSet, (uint)Config.MOUSE_BUTTON_CODES.Right);
+                SavePedalBind(currentPedalToSet, (uint)CustomButtons.MOUSE_BUTTON_CODES.MouseRight);
             }
 
             StatusText.Content = BIND_BUTTON_TEXT;
@@ -134,6 +139,7 @@ namespace biped
                     config.Right = keyCode;
                     break;
             }
+            lastBindTime = DateTime.Now;
         }
 
         private Key VKeyToKey(int vKey)
@@ -159,11 +165,11 @@ namespace biped
         {
             switch (btnCode)
             {
-                case (uint)Config.MOUSE_BUTTON_CODES.Left:
+                case (uint)CustomButtons.MOUSE_BUTTON_CODES.MouseLeft:
                     return $"Mouse Btn Left ({btnCode})";
-                case (uint)Config.MOUSE_BUTTON_CODES.Middle:
+                case (uint)CustomButtons.MOUSE_BUTTON_CODES.MouseMiddle:
                     return $"Mouse Btn Middle ({btnCode})";
-                case (uint)Config.MOUSE_BUTTON_CODES.Right:
+                case (uint)CustomButtons.MOUSE_BUTTON_CODES.MouseRight:
                     return $"Mouse Btn Right ({btnCode})";
                 default:
                     return $"{VKeyToKey(VKeyFromScanCode(btnCode)).ToString()} ({btnCode})";
@@ -186,6 +192,11 @@ namespace biped
                 biped.UpdateConfig(config);
         }
 
+        private bool WasJustBound()
+        {
+            return lastBindTime.AddSeconds(0.5) > DateTime.Now;
+        }
+
         private void LeftText_PreviewMouseUp(object sender, MouseButtonEventArgs e)
         {
             RecordPedalBind(Pedal.LEFT);
@@ -194,13 +205,11 @@ namespace biped
         private void MiddleText_PreviewMouseUp(object sender, MouseButtonEventArgs e)
         {
             RecordPedalBind(Pedal.MIDDLE);
-
         }
 
         private void RightText_PreviewMouseUp(object sender, MouseButtonEventArgs e)
         {
             RecordPedalBind(Pedal.RIGHT);
-
         }
 
         private void MenuQuit_Click(object sender, RoutedEventArgs e)

--- a/Biped/biped.csproj
+++ b/Biped/biped.csproj
@@ -65,6 +65,7 @@
     </ApplicationDefinition>
     <Compile Include="Biped.cs" />
     <Compile Include="Config.cs" />
+    <Compile Include="CustomButtonCodes.cs" />
     <Compile Include="Input.cs" />
     <Compile Include="Registry.cs" />
     <Page Include="MainWindow.xaml">

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ exit right click on the tray icon.
 
 ## Command Line Options
 
-The application also allows launching with command line parameters to configure your pedals when launching the application.
+The application also supports command line parameters to configure your pedals when launching the application.
 
 ```biped2.exe -left [keycode] -middle [keycode] -right [keycode]```
 

--- a/README.md
+++ b/README.md
@@ -6,5 +6,18 @@ The existing Pedable application lacks some features (multiple pedals down at on
 
 This is a super simple alternative for those who want to send keyboard input with their foot pedals.
 
+Pedals can also be configured to send left, right, or middle mouse click events.
+
 Run Biped.exe and use the GUI to configure your pedals.  Configuration is stored in the registry.  Biped will run in the system tray; to
 exit right click on the tray icon.
+
+
+## Command Line Options
+
+The application also supports command line parameters to configure your pedals when launching the application.
+
+```biped2.exe -left [keycode] -middle [keycode] -right [keycode]```
+
+The parameters can be in any order but all three pedals must be mapped to a value.
+
+Key codes can be obtained by viewing the values displayed in the GUI.

--- a/README.md
+++ b/README.md
@@ -6,5 +6,18 @@ The existing Pedable application lacks some features (multiple pedals down at on
 
 This is a super simple alternative for those who want to send keyboard input with their foot pedals.
 
+Pedals can also be configured to send left, right, or middle mouse click events.
+
 Run Biped.exe and use the GUI to configure your pedals.  Configuration is stored in the registry.  Biped will run in the system tray; to
 exit right click on the tray icon.
+
+
+## Command Line Options
+
+The application also allows launching with command line parameters to configure your pedals when launching the application.
+
+```biped2.exe -left [keycode] -middle [keycode] -right [keycode]```
+
+The parameters can be in any order but all three pedals must be mapped to a value.
+
+Key codes can be obtained by viewing the values displayed in the GUI.


### PR DESCRIPTION
Awesome project that is finding life in the arcade emulation space with the release of the Sinden Lightgun. The Infinity Pedal is a great solution for playing games like the Time Crisis series.

I've added a few features to the application that allows the pedal bindings to be set at runtime via command line options so that when launching games from a Frontend application they can be configured based on the button mappings of the emulator.

I also added support for binding/sending mouse left/right/middle events via the pedals.